### PR TITLE
Fix check for volatile in putfield_or_static

### DIFF
--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -3308,7 +3308,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
   __ movl(rdx, flags);
 
   // Check for volatile store
-  __ testl(rdx, rdx);
+  __ testl(rdx, 1 << ConstantPoolCacheEntry::is_volatile_shift);
   __ jcc(Assembler::zero, notVolatile);
 
   putfield_or_static_helper(byte_no, is_static, rc, obj, off, flags);


### PR DESCRIPTION
rdx contains the raw flags without shifts. We want to check if it contains the volatile bit, so testl against the volatile bit.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * Man Cao ([manc](@caoman) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/tsan pull/4/head:pull/4`
`$ git checkout pull/4`
