### PR TITLE
Enable aarch64 build in jdk/tsan.

### DIFF
--- a/make/autoconf/hotspot.m4
+++ b/make/autoconf/hotspot.m4
@@ -555,7 +555,7 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_FEATURES],
     AC_MSG_RESULT([no, forced])
     INCLUDE_TSAN="false"
   # Only enable ThreadSanitizer on supported platforms
-  elif test "x$OPENJDK_TARGET_OS" = "xlinux" && test "x$OPENJDK_TARGET_CPU" = "xx86_64"; then
+  elif test "x$OPENJDK_TARGET_OS" = "xlinux" && (test "x$OPENJDK_TARGET_CPU" = "xx86_64" || test "x$OPENJDK_TARGET_CPU" = "xaarch64"); then
     AC_MSG_RESULT([yes])
     NON_MINIMAL_FEATURES="$NON_MINIMAL_FEATURES tsan"
     INCLUDE_TSAN="true"


### PR DESCRIPTION
Enable INCLUDE_TSAN in aarch64, and add the option -fno-experiment-isel when build aarch64 to
avoid a known bug [1] in llvm-8, recommended compiler in jdk/tsan,
which generates wrong debug info.

In addition, change aarch64 release build option from -O3 to -Os to prevent a crash occurs
in build process, caused by a known issue [2].

[1] https://bugs.llvm.org/show_bug.cgi?id=40887
[2] https://bugs.llvm.org/show_bug.cgi?id=44581
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/tsan pull/5/head:pull/5`
`$ git checkout pull/5`
