### PR TITLE
Add a limition to allocate object heap in aarch64 with tsan enabled.

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -537,6 +537,29 @@ bool os::has_allocatable_memory_limit(julong* limit) {
     *limit = (julong)rlim.rlim_cur;
     result = true;
   }
+
+#if (INCLUDE_TSAN) && defined(AARCH64)
+  // Current TSAN memory mapping for 48bits aarch64, a large continuous space could be allocated between
+  // kMidAppMemBeg = 0x0aaaa00000000ull and kMidAppMemEnd = 0x0aaaf00000000ull, which is only 20GB size.
+  // Take 16GB here for safer allocation.
+  const julong max_avail_vmspace = 16ULL * G; // 16GB
+  const u8 msb_in_aarch64 = 47; // Only support 48-bits space now.
+
+  // Based on tsan memory mapping for 48bits aarch64,
+  // libjvm.so will be loaded between kHiAppMemBeg = 0x0ffff00000000ull and kHiAppMemEnd = 0x1000000000000ull
+  u8 vm_addr_u8 = reinterpret_cast<u8>(&__FUNCTION__);
+  // High address in 48bits user space is like 0x0000ffffxxxxxxxx.
+  assert((vm_addr_u8  >> msb_in_aarch64) == 0x1, "warning: allocation could fail in non 48-bit address space.");
+
+  if (result) {
+    *limit = MIN2(*limit, max_avail_vmspace);
+  } else {
+    *limit = max_avail_vmspace;
+  }
+
+  result = true;
+#endif
+
 #ifdef _LP64
   return result;
 #else


### PR DESCRIPTION
Vm will calculate max heap size according to the physical ram if user
doesn't specify the size(-Xmx). However, with tsan 48-bits memory
mapping of aarch64, it's hard to allocate the large continuous vm
space. Heap allocation often fail in this case, thus, add a limitation
at the end of the heap size calculation to prevent to exceed the
avaiable size. Currently, only support 48-bits address space.

Can reproduce the behavior by launching "java --version" in a machine
with huge physical memory.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * Man Cao ([manc](@caoman) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/tsan pull/6/head:pull/6`
`$ git checkout pull/6`
