### PR TITLE
Add function entry/exit instruments for aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -1509,6 +1509,10 @@ void InterpreterMacroAssembler::notify_method_entry() {
                  rthread, c_rarg1);
   }
 
+  TSAN_RUNTIME_ONLY(call_VM(noreg,
+                            CAST_FROM_FN_PTR(address,
+                            SharedRuntime::tsan_interp_method_entry)));
+
   // RedefineClasses() tracing support for obsolete method entry
   if (log_is_enabled(Trace, redefine, class, obsolete)) {
     get_method(c_rarg1);
@@ -1541,6 +1545,13 @@ void InterpreterMacroAssembler::notify_method_exit(
     bind(L);
     pop(state);
   }
+
+  TSAN_RUNTIME_ONLY(
+    push(state);
+    call_VM_leaf(CAST_FROM_FN_PTR(address,
+                 SharedRuntime::tsan_interp_method_exit));
+    pop(state);
+  );
 
   {
     SkipIfEqual skip(this, &DTraceMethodProbes, false);


### PR DESCRIPTION
Add function entry/exit instruments for aarch64, including 3 places:
gernate_normal_entry, generate_native_entry and generate_native_wrapper.

PS, I'm not sure if it's neccessary to instrument tsan into
generate_native_wrapper, which is for compiled code. Now just follow x86.
In addition, all tsan test cases could pass even though I remove the
instruments in generate_native_wrapper.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/tsan pull/7/head:pull/7`
`$ git checkout pull/7`
