### PR TITLE
Avoid jtreg test timeout in aarch64 due to a stackoverflow in process reaper

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -860,6 +860,15 @@ define SetupRunJtregTestBody
     $1_JTREG_LAUNCHER_OPTIONS += -Xmx$$($1_JTREG_MAX_MEM)
   endif
 
+  # With tsan enabled, process reaper often causes SOE. it makes jtreg test failure.
+  ifeq ($(INCLUDE_TSAN), true)
+    ifeq ($(call isTargetCpuArch, aarch64), true)
+      $1_JTREG_BASIC_OPTIONS += -vmoption:-Djdk.lang.processReaperUseDefaultStackSize=true
+      $1_JTREG_LAUNCHER_OPTIONS += -Djdk.lang.processReaperUseDefaultStackSize=true
+      $$(info tsan enabled, process reaper will use default JVM stack size.)
+    endif
+  endif
+
   $1_JTREG_BASIC_OPTIONS += -$$($1_JTREG_TEST_MODE) \
       -verbose:$$(JTREG_VERBOSE) -retain:$$(JTREG_RETAIN) \
       -concurrency:$$($1_JTREG_JOBS) -timeoutFactor:$$(JTREG_TIMEOUT_FACTOR) \


### PR DESCRIPTION
Process reaper has a small size stack by default, 128K. With tsan
enabled, it often causes SOE failure when running jtreg tests. Set
-Djdk.lang.processReaperUseDefaultStackSize=true, to let jtreg test
use default JVM stack size (global variable ThreadStackSize) in
aarch64, which could be configured by -Xss.

I took an investigation about the stackoverflow, [1].
and found the different GLIBC behaviors between x86 and aarch64 stack 
allocation due to default stack size in openjdk. x86 will get the stack from 
glibc cached stack because it matches the threshold to allocate a stack from 
cached stack, but aarch64 not.

[1] https://groups.google.com/forum/#!topic/thread-sanitizer/RsPcxUXBokg
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/tsan pull/8/head:pull/8`
`$ git checkout pull/8`
