### PR TITLE
Add aarch64 specific lock/unlock tsan instruments

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1789,6 +1789,14 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // Slow path will re-enter here
 
     __ bind(lock_done);
+
+    TSAN_RUNTIME_ONLY(
+      __ pusha();
+      __ call_VM(noreg,
+                 CAST_FROM_FN_PTR(address, SharedRuntime::tsan_oop_lock),
+                 obj_reg);
+      __ popa();
+    );
   }
 
 
@@ -1904,6 +1912,15 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     __ ldr(obj_reg, Address(oop_handle_reg, 0));
 
     __ resolve(IS_NOT_NULL, obj_reg);
+
+    TSAN_RUNTIME_ONLY(
+      __ pusha();
+      __ call_VM(noreg,
+                 CAST_FROM_FN_PTR(address, SharedRuntime::tsan_oop_unlock),
+                 obj_reg);
+      __ popa();
+    );
+
 
     Label done;
 

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5848,7 +5848,10 @@ void ClassFileParser::fill_instance_klass(InstanceKlass* ik, bool changed_by_loa
 #ifdef ASSERT
       u8 id_u8 = reinterpret_cast<u8>(id);
       assert((id_u8 & right_n_bits(3)) == 0, "jmethodID is not aligned");
-      assert((id_u8 & left_n_bits(17)) == 0, "jmethodID is not aligned");
+      AMD64_ONLY(assert((id_u8 & left_n_bits(17)) == 0, "jmethodID is not aligned");)
+      AARCH64_ONLY(id_u8 >>= 36;
+                   assert(id_u8 == 0 || id_u8 == 0xaaa || id_u8 == 0xfff, "jmethodID is not aligned");
+                   )
 #endif
     }
   }


### PR DESCRIPTION
Add aarch64 specific lock/unlock instruments into interpreter and
runtime.

Update an assertion in aarch64 due to different memory layout.

With tsan enabled, too small java stack often causes SOE, especially
thread "process reaper". Therefore, for running jtreg test in aarch64,
we have to set jdk.lang.processReaperUseDefaultStackSize as true.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/tsan pull/9/head:pull/9`
`$ git checkout pull/9`
