### PR TITLE
Enable field access instrumentation for aarch64

### DIFF
--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -768,23 +768,6 @@ void TemplateTable::index_check_without_pop(Register array, Register index) {
 }
 
 #if INCLUDE_TSAN
-
-TemplateTable::TsanMemoryReleaseAcquireFunction TemplateTable::tsan_release_acquire_method(
-    TsanMemoryReadWriteFunction tsan_function) {
-  if (tsan_function == SharedRuntime::tsan_read1
-      || tsan_function == SharedRuntime::tsan_read2
-      || tsan_function == SharedRuntime::tsan_read4
-      || tsan_function == SharedRuntime::tsan_read8) {
-    return SharedRuntime::tsan_acquire;
-  } else if (tsan_function == SharedRuntime::tsan_write1
-      || tsan_function == SharedRuntime::tsan_write2
-      || tsan_function == SharedRuntime::tsan_write4
-      || tsan_function == SharedRuntime::tsan_write8) {
-    return SharedRuntime::tsan_release;
-  }
-  ShouldNotReachHere();
-  return NULL;
-}
 
 void TemplateTable::tsan_observe_get_or_put(
     const Address &field,

--- a/src/hotspot/cpu/x86/templateTable_x86.hpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,40 +43,5 @@
                                         Register obj, Register off, Register flags);
   static void fast_storefield_helper(Address field, Register rax);
 
-#if INCLUDE_TSAN
-  typedef void (*TsanMemoryReleaseAcquireFunction)(void* /* address */);
-  typedef void (*TsanMemoryReadWriteFunction)(void* /* address */,
-                                              Method* /* method */,
-                                              address /* bcp */);
-
-  // The corresponding tsan_acquire/release function for a
-  // TsanMemoryReadWriteFunction.
-  static TsanMemoryReleaseAcquireFunction tsan_release_acquire_method(
-      TsanMemoryReadWriteFunction tsan_function);
-
-  // Tell tsan that a member/static variable has been read from or written to.
-  // tsan_function must be one of the SharedRuntime::tsan_read/write*
-  // functions.
-  // Flags is the register that contains the field cache entry flags bitfield.
-  // Because the field may be volatile, for a write, this function must be
-  // called before the write; for a read, this function must be called after
-  // the read. This way the acquire/release is ordered correctly relative to the
-  // read/write.
-  static void tsan_observe_get_or_put(
-      const Address &field,
-      Register flags,
-      TsanMemoryReadWriteFunction tsan_function,
-      TosState tos);
-
-  // Tell tsan that an array has been read from or written to.
-  // tsan_function must be one of the SharedRuntime::tsan_read/write*
-  // functions.
-  // Unlike tsan_observe_get_or_put(), the ordering relative to the
-  // read/write does not matter since array loads/stores are never volatile.
-  static void tsan_observe_load_or_store(
-      const Address& address,
-      TsanMemoryReadWriteFunction tsan_function);
-
-#endif  // INCLUDE_TSAN
 
 #endif // CPU_X86_TEMPLATETABLE_X86_HPP

--- a/src/hotspot/share/interpreter/templateTable.cpp
+++ b/src/hotspot/share/interpreter/templateTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,9 @@
 #include "interpreter/interp_masm.hpp"
 #include "interpreter/templateTable.hpp"
 #include "runtime/timerTrace.hpp"
+#if INCLUDE_TSAN
+#include "runtime/sharedRuntime.hpp"
+#endif
 
 #ifdef CC_INTERP
 
@@ -67,6 +70,27 @@ void Template::generate(InterpreterMacroAssembler* masm) {
 
 //----------------------------------------------------------------------------------------------------
 // Implementation of TemplateTable: Platform-independent helper routines
+
+#if INCLUDE_TSAN
+
+TemplateTable::TsanMemoryReleaseAcquireFunction TemplateTable::tsan_release_acquire_method(
+    TsanMemoryReadWriteFunction tsan_function) {
+  if (tsan_function == SharedRuntime::tsan_read1
+      || tsan_function == SharedRuntime::tsan_read2
+      || tsan_function == SharedRuntime::tsan_read4
+      || tsan_function == SharedRuntime::tsan_read8) {
+    return SharedRuntime::tsan_acquire;
+  } else if (tsan_function == SharedRuntime::tsan_write1
+      || tsan_function == SharedRuntime::tsan_write2
+      || tsan_function == SharedRuntime::tsan_write4
+      || tsan_function == SharedRuntime::tsan_write8) {
+    return SharedRuntime::tsan_release;
+  }
+  ShouldNotReachHere();
+  return NULL;
+}
+
+#endif
 
 void TemplateTable::call_VM(Register oop_result, address entry_point) {
   assert(_desc->calls_vm(), "inconsistent calls_vm information");

--- a/src/hotspot/share/interpreter/templateTable.hpp
+++ b/src/hotspot/share/interpreter/templateTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -350,6 +350,42 @@ class TemplateTable: AllStatic {
   // Templates
   static Template* template_for     (Bytecodes::Code code)  { Bytecodes::check     (code); return &_template_table     [code]; }
   static Template* template_for_wide(Bytecodes::Code code)  { Bytecodes::wide_check(code); return &_template_table_wide[code]; }
+
+#if INCLUDE_TSAN
+   typedef void (*TsanMemoryReleaseAcquireFunction)(void* /* address */);
+
+   typedef void (*TsanMemoryReadWriteFunction)(void* /* address */,
+                                               Method* /* method */,
+                                               address /* bcp */);
+
+   // The corresponding tsan_acquire/release function for a
+   // TsanMemoryReadWriteFunction.
+   static TsanMemoryReleaseAcquireFunction tsan_release_acquire_method(
+       TsanMemoryReadWriteFunction tsan_function);
+
+   // Tell tsan that a member/static variable has been read from or written to.
+   // tsan_function must be one of the SharedRuntime::tsan_read/write*
+   // functions.
+   // Flags is the register that contains the field cache entry flags bitfield.
+   // Because the field may be volatile, for a write, this function must be
+   // called before the write; for a read, this function must be called after
+   // the read. This way the acquire/release is ordered correctly relative to the
+   // read/write.
+   static void tsan_observe_get_or_put(
+       const Address &field,
+       Register flags,
+       TsanMemoryReadWriteFunction tsan_function,
+       TosState tos);
+
+   // Tell tsan that an array has been read from or written to.
+   // tsan_function must be one of the SharedRuntime::tsan_read/write*
+   // functions.
+   // Unlike tsan_observe_get_or_put(), the ordering relative to the
+   // read/write does not matter since array loads/stores are never volatile.
+   static void tsan_observe_load_or_store(
+       const Address& address,
+       TsanMemoryReadWriteFunction tsan_function);
+#endif
 
   // Platform specifics
 #include CPU_HEADER(templateTable)


### PR DESCRIPTION
This patch enables field access instrumentation for aarch64.

According to the implementation of x86, this patch inserts TSAN
functions in interpreter (templateTable_aarch64.cpp) at three places
which can cover all field accesses:

  1. getfield_or_static
  2. putfield_or_static
  3. load_field_cp_cache_entry

This patch implements the annotation
'java.util.concurrent.annotation.LazyInit', which causes TSAN to ignore
races on that field. References that marked by @LazyInit are not simply
ignored, but a release/acquire is performed on them. This is so that any
following accesses to its member variables are not also reported as race.

This patch also moves some architecture independent code into common
files.

TODO:
  - Array access instrumentation will be updated in later patch.

[Tests]
test/hotspot/jtreg/tsan/RacyByteMemberLoopTest.java
test/hotspot/jtreg/tsan/RacyCharMemberLoopTest.java
test/hotspot/jtreg/tsan/RacyShortMemberLoopTest.java
test/hotspot/jtreg/tsan/RacyIntMemberLoopTest.java
test/hotspot/jtreg/tsan/RacyFloatMemberLoopTest.java
test/hotspot/jtreg/tsan/RacyLongMemberLoopTest.java
test/hotspot/jtreg/tsan/RacyDoubleMemberLoopTest.java
test/hotspot/jtreg/tsan/LazyInitLoopTest.java
test/hotspot/jtreg/tsan/LazyInitReferenceLoopTest.java

With this patch, those test cases above passed on aarch64.
No new failure found on x86.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/tsan pull/11/head:pull/11`
`$ git checkout pull/11`
