### PR TITLE
Add the code to track object allocation for aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -3631,6 +3631,14 @@ void TemplateTable::_new() {
       __ pop(atos); // restore the return value
 
     }
+
+     TSAN_RUNTIME_ONLY(
+      // return value of new oop is in r0.
+      __ push(atos);
+      __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::tsan_track_obj), r0);
+      __ pop(atos);
+    );
+
     __ b(done);
   }
 


### PR DESCRIPTION
Jdk/tsan has added the code in gc to track the oop move/collect, thus,
in this patch, what we only need to do is to track the oop allocation
in interpreter.

Jdk/tsan builds a hash table to track all oops, oop address as hash key.
Any move/collect of oop detected by code at the end of each gc will
update the hash table, then call tsan APIs _tsan_java_move or
_tsan_java_free to notify llvm/tsan.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/tsan pull/12/head:pull/12`
`$ git checkout pull/12`
