### PR TITLE
Enable array access instrumentation for aarch64

### DIFF
--- a/src/hotspot/share/interpreter/templateTable.hpp
+++ b/src/hotspot/share/interpreter/templateTable.hpp
@@ -360,8 +360,7 @@ class TemplateTable: AllStatic {
 
    // The corresponding tsan_acquire/release function for a
    // TsanMemoryReadWriteFunction.
-   static TsanMemoryReleaseAcquireFunction tsan_release_acquire_method(
-       TsanMemoryReadWriteFunction tsan_function);
+   static TsanMemoryReleaseAcquireFunction tsan_release_acquire_method(TsanMemoryReadWriteFunction tsan_function);
 
    // Tell tsan that a member/static variable has been read from or written to.
    // tsan_function must be one of the SharedRuntime::tsan_read/write*
@@ -371,20 +370,18 @@ class TemplateTable: AllStatic {
    // called before the write; for a read, this function must be called after
    // the read. This way the acquire/release is ordered correctly relative to the
    // read/write.
-   static void tsan_observe_get_or_put(
-       const Address &field,
-       Register flags,
-       TsanMemoryReadWriteFunction tsan_function,
-       TosState tos);
+   static void tsan_observe_get_or_put(const Address &field,
+                                       Register flags,
+                                       TsanMemoryReadWriteFunction tsan_function,
+                                       TosState tos);
 
    // Tell tsan that an array has been read from or written to.
    // tsan_function must be one of the SharedRuntime::tsan_read/write*
    // functions.
    // Unlike tsan_observe_get_or_put(), the ordering relative to the
    // read/write does not matter since array loads/stores are never volatile.
-   static void tsan_observe_load_or_store(
-       const Address& address,
-       TsanMemoryReadWriteFunction tsan_function);
+   static void tsan_observe_load_or_store(const Address& address,
+                                          TsanMemoryReadWriteFunction tsan_function);
 #endif
 
   // Platform specifics


### PR DESCRIPTION
This patch is a subsequent patch of https://github.com/openjdk/tsan/pull/11.

This patch inserts TSAN instrumentation in interpreter at array access
bytecodes like below:

- aaload, baload, caload, daload, iaload, laload, saload
- aastore, bastore, castore, dastore, iastore, lastore, sastore

Besides those normal array access bytecodes, some fast bytecodes (e.g.
fast_icaload) would result in memory access as well. TSAN has disabled
bytecode rewrite in previous patch. This patch inserts assertions
in 'fast_xaccess', 'fast_accessfield' and 'fast_icaload' to make sure
that TSAN would not reach there.


[TEST]
With this patch, all TSAN test cases passed both on x86 and aarch64.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/tsan pull/13/head:pull/13`
`$ git checkout pull/13`
