### PR TITLE
8336924: Disable jcheck for issue number in TSAN project

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -5,7 +5,7 @@ jbs=JDK
 version=21
 
 [checks]
-error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists
+error=author,committer,reviewers,merge,executable,symlink,message,hg-tag,whitespace,problemlists
 
 [repository]
 tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)


### PR DESCRIPTION
Hi all,

https://github.com/openjdk/tsan/pull/19 sees a jcheck error "The commit message does not reference any issue. To add an issue reference to this PR, edit the title to be of the format issue number: message."
TSAN project currently does not need an issue for a commit, so I propose we disable this check.

The jcheck was probably enabled in Sep, 2020 by https://github.com/openjdk/tsan/commit/e0c8d4420c8e1a84581927cf77314498b8e5aa52.  However, TSAN project did not have new PRs except merges after Sep, 2020. (I think this check probably skips checking merge commits and merge PRs.)

-Man

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336924](https://bugs.openjdk.org/browse/JDK-8336924): Disable jcheck for issue number in TSAN project (**Bug** - P4)


### Reviewers
 * [Liam Miller-Cushon](https://openjdk.org/census#cushon) (@cushon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/tsan.git pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.org/tsan.git pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/tsan/pull/20.diff">https://git.openjdk.org/tsan/pull/20.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/tsan/pull/20#issuecomment-2243551689)