### PR TITLE
Tsan oop map table hash fix

### DIFF
--- a/src/hotspot/share/gc/shared/weakProcessor.cpp
+++ b/src/hotspot/share/gc/shared/weakProcessor.cpp
@@ -94,6 +94,7 @@ uint WeakProcessor::ergo_workers(uint max_workers) {
 
 void WeakProcessor::Task::initialize() {
   assert(_nworkers != 0, "must be");
+  TSAN_ONLY(assert(_nworkers_completed == 0, "must be");)
   assert(_times == nullptr || _nworkers <= _times->max_threads(),
          "nworkers (%u) exceeds max threads (%u)",
          _nworkers, _times->max_threads());
@@ -109,6 +110,9 @@ WeakProcessor::Task::Task(uint nworkers) : Task(nullptr, nworkers) {}
 WeakProcessor::Task::Task(WeakProcessorTimes* times, uint nworkers) :
   _times(times),
   _nworkers(nworkers),
+#if INCLUDE_TSAN
+  _nworkers_completed(0),
+#endif
   _storage_states()
 {
   initialize();

--- a/src/hotspot/share/gc/shared/weakProcessor.hpp
+++ b/src/hotspot/share/gc/shared/weakProcessor.hpp
@@ -87,6 +87,7 @@ class WeakProcessor::Task {
 
   WeakProcessorTimes* _times;
   uint _nworkers;
+  TSAN_ONLY(uint _nworkers_completed;)
   OopStorageSetWeakParState<false, false> _storage_states;
 
   void initialize();

--- a/src/hotspot/share/gc/shared/weakProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shared/weakProcessor.inline.hpp
@@ -97,7 +97,12 @@ void WeakProcessor::Task::work(uint worker_id,
   }
 
   TSAN_RUNTIME_ONLY(
-    TsanOopMap::notify_tsan_for_freed_and_moved_objects();
+    MutexLocker mu(TsanOopMap_lock, Mutex::_no_safepoint_check_flag);
+    _nworkers_completed ++;
+    assert((_nworkers >= _nworkers_completed), "must be");
+    if (_nworkers == _nworkers_completed) {
+      TsanOopMap::notify_tsan_for_freed_and_moved_objects();
+    }
   );
 }
 

--- a/src/hotspot/share/tsan/tsanOopMap.cpp
+++ b/src/hotspot/share/tsan/tsanOopMap.cpp
@@ -227,8 +227,8 @@ void TsanOopMap::notify_tsan_for_freed_and_moved_objects() {
                                  &target_low, &target_high,
                                  &n_downward_moves);
 
-    // Add back the entries with moved oops. New hashes are computed
-    // using the new oop address for the entries.
+    // Add back the entries with moved oops. New hashes for the entries
+    // are computed using the new oop address.
     for (int i = 0; i < moved_entries.length(); i++) {
       TsanOopMapTableKey* entry = moved_entries.at(i);
       _oop_map->add_entry(entry, entry->obj()->size());

--- a/src/hotspot/share/tsan/tsanOopMap.cpp
+++ b/src/hotspot/share/tsan/tsanOopMap.cpp
@@ -205,6 +205,7 @@ OopStorage* TsanOopMap::oop_storage() {
 void TsanOopMap::notify_tsan_for_freed_and_moved_objects() {
   assert(_oop_map != nullptr, "must be");
   assert(SafepointSynchronize::is_at_safepoint(), "must be");
+  assert(TsanOopMap_lock->is_locked(), "sanity check");
 
   bool disjoint_regions;
   int n_downward_moves = 0;
@@ -220,7 +221,6 @@ void TsanOopMap::notify_tsan_for_freed_and_moved_objects() {
   GrowableArray<TsanOopMapImpl::MovedEntry> moved_entries(len);
 
   {
-    MutexLocker mu(TsanOopMap_lock, Mutex::_no_safepoint_check_flag);
     _oop_map->collect_moved_objects_and_notify_freed(
                                  &moved_entries,
                                  &moves, &source_low, &source_high,

--- a/src/hotspot/share/tsan/tsanOopMap.cpp
+++ b/src/hotspot/share/tsan/tsanOopMap.cpp
@@ -220,22 +220,20 @@ void TsanOopMap::notify_tsan_for_freed_and_moved_objects() {
   GrowableArray<TsanOopMapImpl::PendingMove> moves(len);
   GrowableArray<TsanOopMapImpl::MovedEntry> moved_entries(len);
 
-  {
-    _oop_map->collect_moved_objects_and_notify_freed(
+  _oop_map->collect_moved_objects_and_notify_freed(
                                  &moved_entries,
                                  &moves, &source_low, &source_high,
                                  &target_low, &target_high,
                                  &n_downward_moves);
 
-    // Add back the entries with moved oops. New hashes for the entries
-    // are computed using the new oop address.
-    for (int i = 0; i < moved_entries.length(); i++) {
-      const TsanOopMapImpl::MovedEntry &e = moved_entries.at(i);
-      _oop_map->add_entry(e.key(), e.value());
-    }
+  // Add back the entries with moved oops. New hashes for the entries
+  // are computed using the new oop address.
+  for (int i = 0; i < moved_entries.length(); i++) {
+    const TsanOopMapImpl::MovedEntry &e = moved_entries.at(i);
+    _oop_map->add_entry(e.key(), e.value());
+    delete e.key();
   }
 
-  // No lock is needed after this point.
   if (moves.length() != 0) {
     // Notify Tsan about moved objects.
     disjoint_regions = (source_low >= target_high || source_high <= target_low);

--- a/src/hotspot/share/tsan/tsanOopMap.cpp
+++ b/src/hotspot/share/tsan/tsanOopMap.cpp
@@ -217,7 +217,7 @@ void TsanOopMap::notify_tsan_for_freed_and_moved_objects() {
   int len = MAX2((int)(_oop_map->size()), 100000);
   ResourceMark rm;
   GrowableArray<TsanOopMapImpl::PendingMove> moves(len);
-  GrowableArray<TsanOopMapTableKey*> moved_entries(len);
+  GrowableArray<TsanOopMapImpl::MovedEntry> moved_entries(len);
 
   {
     MutexLocker mu(TsanOopMap_lock, Mutex::_no_safepoint_check_flag);
@@ -230,8 +230,8 @@ void TsanOopMap::notify_tsan_for_freed_and_moved_objects() {
     // Add back the entries with moved oops. New hashes for the entries
     // are computed using the new oop address.
     for (int i = 0; i < moved_entries.length(); i++) {
-      TsanOopMapTableKey* entry = moved_entries.at(i);
-      _oop_map->add_entry(entry, entry->obj()->size());
+      const TsanOopMapImpl::MovedEntry &e = moved_entries.at(i);
+      _oop_map->add_entry(e.key(), e.value());
     }
   }
 

--- a/src/hotspot/share/tsan/tsanOopMap.cpp
+++ b/src/hotspot/share/tsan/tsanOopMap.cpp
@@ -218,19 +218,19 @@ void TsanOopMap::notify_tsan_for_freed_and_moved_objects() {
   ResourceMark rm;
   GrowableArray<TsanOopMapImpl::PendingMove> moves(len);
   GrowableArray<TsanOopMapTableKey*> moved_entries(len);
-  GrowableArray<int> moved_entry_sizes(len);
 
   {
     MutexLocker mu(TsanOopMap_lock, Mutex::_no_safepoint_check_flag);
     _oop_map->collect_moved_objects_and_notify_freed(
-                                 &moved_entries, &moved_entry_sizes,
+                                 &moved_entries,
                                  &moves, &source_low, &source_high,
                                  &target_low, &target_high,
                                  &n_downward_moves);
 
+    // Add back the entries with moved oops. New hashes are computed
+    // using the new oop address for the entries.
     for (int i = 0; i < moved_entries.length(); i++) {
       TsanOopMapTableKey* entry = moved_entries.at(i);
-      //_oop_map->add_entry(entry, moved_entry_sizes.at(i));
       _oop_map->add_entry(entry, entry->obj()->size());
     }
   }

--- a/src/hotspot/share/tsan/tsanOopMapTable.cpp
+++ b/src/hotspot/share/tsan/tsanOopMapTable.cpp
@@ -122,20 +122,20 @@ size_t TsanOopMapTable::find(oop obj) {
 // - Colllect objects moved bt GC and add a PendingMove for each moved
 //   objects in a GrowableArray.
 void TsanOopMapTable::collect_moved_objects_and_notify_freed(
-         GrowableArray<TsanOopMapTableKey*> *moved_entries,
+         GrowableArray<TsanOopMapImpl::MovedEntry> *moved_entries,
          GrowableArray<TsanOopMapImpl::PendingMove> *moves,
          char **src_low, char **src_high,
          char **dest_low, char **dest_high,
          int *n_downward_moves) {
   struct IsDead {
-    GrowableArray<TsanOopMapTableKey*> *_moved_entries;
+    GrowableArray<TsanOopMapImpl::MovedEntry> *_moved_entries;
     GrowableArray<TsanOopMapImpl::PendingMove> *_moves;
     char **_src_low;
     char **_src_high;
     char **_dest_low;
     char **_dest_high;
     int  *_n_downward_moves;
-    IsDead(GrowableArray<TsanOopMapTableKey*> *moved_entries,
+    IsDead(GrowableArray<TsanOopMapImpl::MovedEntry> *moved_entries,
            GrowableArray<TsanOopMapImpl::PendingMove> *moves,
            char **src_low, char **src_high,
            char **dest_low, char **dest_high,
@@ -165,7 +165,8 @@ void TsanOopMapTable::collect_moved_objects_and_notify_freed(
         entry.update_obj();
 
         TsanOopMapTableKey* new_entry = new TsanOopMapTableKey(entry);
-        _moved_entries->append(new_entry);
+        TsanOopMapImpl::MovedEntry moved_entry = {new_entry, size};
+        _moved_entries->append(moved_entry);
 
         // Unlink the entry without releasing the weak_handle.
         return true;

--- a/src/hotspot/share/tsan/tsanOopMapTable.cpp
+++ b/src/hotspot/share/tsan/tsanOopMapTable.cpp
@@ -81,12 +81,8 @@ bool TsanOopMapTable::add_entry(TsanOopMapTableKey *entry, size_t size) {
 bool TsanOopMapTable::add_oop_with_size(oop obj, size_t size) {
   TsanOopMapTableKey new_entry(obj);
   bool added;
-  if (obj->fast_no_hash_check()) {
-    added = _table.put_when_absent(new_entry, size);
-  } else {
-    size_t* v = _table.put_if_absent(new_entry, size, &added);
-    assert(*v == size, "sanity");
-  }
+  size_t* v = _table.put_if_absent(new_entry, size, &added);
+  assert(*v == size, "sanity");
 
   if (added) {
     if (_table.maybe_grow(true /* use_large_table_sizes */)) {

--- a/src/hotspot/share/tsan/tsanOopMapTable.cpp
+++ b/src/hotspot/share/tsan/tsanOopMapTable.cpp
@@ -123,14 +123,12 @@ size_t TsanOopMapTable::find(oop obj) {
 //   objects in a GrowableArray.
 void TsanOopMapTable::collect_moved_objects_and_notify_freed(
          GrowableArray<TsanOopMapTableKey*> *moved_entries,
-         GrowableArray<int> *moved_entry_sizes,
          GrowableArray<TsanOopMapImpl::PendingMove> *moves,
          char **src_low, char **src_high,
          char **dest_low, char **dest_high,
          int *n_downward_moves) {
   struct IsDead {
     GrowableArray<TsanOopMapTableKey*> *_moved_entries;
-    GrowableArray<int> *_moved_entry_sizes;
     GrowableArray<TsanOopMapImpl::PendingMove> *_moves;
     char **_src_low;
     char **_src_high;
@@ -138,11 +136,10 @@ void TsanOopMapTable::collect_moved_objects_and_notify_freed(
     char **_dest_high;
     int  *_n_downward_moves;
     IsDead(GrowableArray<TsanOopMapTableKey*> *moved_entries,
-           GrowableArray<int> *moved_entry_sizes,
            GrowableArray<TsanOopMapImpl::PendingMove> *moves,
            char **src_low, char **src_high,
            char **dest_low, char **dest_high,
-           int  *n_downward_moves) : _moved_entries(moved_entries), _moved_entry_sizes(moved_entry_sizes),
+           int  *n_downward_moves) : _moved_entries(moved_entries),
                                      _moves(moves), _src_low(src_low), _src_high(src_high),
                                      _dest_low(dest_low), _dest_high(dest_high),
                                      _n_downward_moves(n_downward_moves) {}
@@ -169,13 +166,12 @@ void TsanOopMapTable::collect_moved_objects_and_notify_freed(
 
         TsanOopMapTableKey* new_entry = new TsanOopMapTableKey(entry);
         _moved_entries->append(new_entry);
-        _moved_entry_sizes->append(size);
 
-        // Unlink the entry.
+        // Unlink the entry without releasing the weak_handle.
         return true;
       }
       return false;
     }
-  } is_dead(moved_entries, moved_entry_sizes, moves, src_low, src_high, dest_low, dest_high, n_downward_moves);
+  } is_dead(moved_entries, moves, src_low, src_high, dest_low, dest_high, n_downward_moves);
   _table.unlink(&is_dead);
 }

--- a/src/hotspot/share/tsan/tsanOopMapTable.cpp
+++ b/src/hotspot/share/tsan/tsanOopMapTable.cpp
@@ -71,6 +71,8 @@ TsanOopMapTable::~TsanOopMapTable() {
 }
 
 bool TsanOopMapTable::add_entry(TsanOopMapTableKey *entry, size_t size) {
+  assert(TsanOopMap_lock->is_locked(), "sanity check");
+
   bool added;
   size_t* v = _table.put_if_absent(*entry, size, &added);
   assert(added, "must be");
@@ -79,6 +81,8 @@ bool TsanOopMapTable::add_entry(TsanOopMapTableKey *entry, size_t size) {
 }
 
 bool TsanOopMapTable::add_oop_with_size(oop obj, size_t size) {
+  assert(TsanOopMap_lock->is_locked(), "sanity check");
+
   TsanOopMapTableKey new_entry(obj);
   bool added;
   size_t* v = _table.put_if_absent(new_entry, size, &added);

--- a/src/hotspot/share/tsan/tsanOopMapTable.cpp
+++ b/src/hotspot/share/tsan/tsanOopMapTable.cpp
@@ -139,8 +139,8 @@ void TsanOopMapTable::collect_moved_objects_and_notify_freed(
            GrowableArray<TsanOopMapImpl::PendingMove> *moves,
            char **src_low, char **src_high,
            char **dest_low, char **dest_high,
-           int  *n_downward_moves) : _moved_entries(moved_entries),
-                                     _moves(moves), _src_low(src_low), _src_high(src_high),
+           int  *n_downward_moves) : _moved_entries(moved_entries), _moves(moves),
+                                     _src_low(src_low), _src_high(src_high),
                                      _dest_low(dest_low), _dest_high(dest_high),
                                      _n_downward_moves(n_downward_moves) {}
     bool do_entry(TsanOopMapTableKey& entry, size_t size) {

--- a/src/hotspot/share/tsan/tsanOopMapTable.hpp
+++ b/src/hotspot/share/tsan/tsanOopMapTable.hpp
@@ -124,7 +124,6 @@ class TsanOopMapTable : public CHeapObj<mtInternal> {
 
   void collect_moved_objects_and_notify_freed(
            GrowableArray<TsanOopMapTableKey*> *moved_entries,
-           GrowableArray<int> *moved_entry_sizes,
            GrowableArray<TsanOopMapImpl::PendingMove> *moves,
            char **src_low, char **src_high,
            char **dest_low, char **dest_high,

--- a/src/hotspot/share/tsan/tsanOopMapTable.hpp
+++ b/src/hotspot/share/tsan/tsanOopMapTable.hpp
@@ -52,7 +52,6 @@ namespace TsanOopMapImpl {
     TsanOopMapTableKey* key() const { return k; }
     size_t value() const { return v; }
   };
-
 }  // namespace TsanOopMapImpl
 
 // For tracking the lifecycle (alloc/move/free) of interesting oops
@@ -70,6 +69,7 @@ class TsanOopMapTableKey : public CHeapObj<mtInternal> {
  public:
   TsanOopMapTableKey(oop obj);
   TsanOopMapTableKey(const TsanOopMapTableKey& src);
+  TsanOopMapTableKey(const TsanOopMapTableKey& src, oop obj);
   TsanOopMapTableKey& operator=(const TsanOopMapTableKey&) = delete;
 
   void release_weak_handle() const;

--- a/src/hotspot/share/tsan/tsanOopMapTable.hpp
+++ b/src/hotspot/share/tsan/tsanOopMapTable.hpp
@@ -32,6 +32,8 @@
 #include "tsan/tsanOopMap.hpp"
 #include "utilities/resizeableResourceHash.hpp"
 
+class TsanOopMapTableKey;
+
 namespace TsanOopMapImpl {
 
   struct PendingMove {
@@ -42,6 +44,13 @@ namespace TsanOopMapImpl {
     char *source_address;
     char *target_address;
     size_t n_bytes;  // number of bytes being moved
+  };
+
+  struct MovedEntry {
+    TsanOopMapTableKey* k;
+    size_t v;
+    TsanOopMapTableKey* key() const { return k; }
+    size_t value() const { return v; }
   };
 
 }  // namespace TsanOopMapImpl
@@ -123,7 +132,7 @@ class TsanOopMapTable : public CHeapObj<mtInternal> {
 #endif
 
   void collect_moved_objects_and_notify_freed(
-           GrowableArray<TsanOopMapTableKey*> *moved_entries,
+           GrowableArray<TsanOopMapImpl::MovedEntry> *moved_entries,
            GrowableArray<TsanOopMapImpl::PendingMove> *moves,
            char **src_low, char **src_high,
            char **dest_low, char **dest_high,

--- a/src/hotspot/share/tsan/tsanOopMapTable.hpp
+++ b/src/hotspot/share/tsan/tsanOopMapTable.hpp
@@ -94,11 +94,11 @@ class TsanOopMapTableKey : public CHeapObj<mtInternal> {
   static unsigned get_hash(const TsanOopMapTableKey& entry) {
     assert(entry._obj != nullptr, "sanity");
     assert(entry._obj == entry.object_no_keepalive(), "sanity");
-    return primitive_hash<oopDesc*>(entry._obj);
+    return primitive_hash<oopDesc*>(entry.object_no_keepalive());
   }
 
   static bool equals(const TsanOopMapTableKey& lhs, const TsanOopMapTableKey& rhs) {
-    return lhs._obj == rhs._obj;
+    return lhs.object_no_keepalive() == rhs.object_no_keepalive();
   }
 };
 


### PR DESCRIPTION
Additional testing on JDK 21 with tsan found some crashes due to using `oop` `identity_hash` for computing the TsanOopMap entry hash. The crashes manifest as following two types:

1) `guarantee(moves_this_cycle) failed: "Impossible to reconcile GC"`

2) `ThreadSanitizer: CHECK failed: tsan_sync.cpp:261 "((*dst_meta)) == ((0))"`

With `-Xlog:tsan=trace` output, I found the same `oop` is added to the map twice in some cases. The second time when an `oop` is added occurs during `InterpreterMacroAssembler::lock_object` path. Apparently a new identity hash is computed for the `oop` with a previous computed identity hash. That causes the `oop` being added again. Later when notifying tsan if the `oop` is moved, it triggers the above crashes depending on the memory layout.

This fix computes `primitive_hash` using the oop address instead of `identity_hash` for entry hash. During GC, `TsanOopMapTable::collect_moved_objects_and_notify_freed` unlinks an entry from the map if the enclosing `oop` is moved. The moved entries are collected into an array and  are inserted back to the map after iterating the map (within a worker thread). That's needed since the entry hash would be different after an `oop` is moved. The operations are protected by the `TsanOopMap_lock`.

Since `primitive_hash` is now used, I also changed `TsanOopMapTableKey::get_hash` and `TsanOopMapTableKey::equals` to use `entry.object_no_keepalive()` instead of `entry._obj`. If `entry._obj` is outdated, it could result incorrect hash value for the current entry. So the updated oop address should be used instead. Running tsan jtreg tests on slowdebug binary run into new failures without the change.

The change is updated to only call `TsanOopMap::notify_tsan_for_freed_and_moved_objects` from the last worker thread that completes the parallel WeakProcessor::Task work.

Testing

Tsan jtreg tests on linux-x64:
```
$ bash configure --with-boot-jdk=/usr/local/google/home/jianglizhou/openjdk/jdk-21.0.1 --with-debug-level=release --disable-warnings-as-errors --with-jtreg=/usr/local/google/home/jianglizhou/github/jtreg/build/images/jtreg --with-stdc++lib=static --disable-precompiled-headers --enable-unlimited-crypto --with-native-debug-symbols=internal --with-default-make-target=jdk-image --disable-warnings-as-errors --with-toolchain-type=clang
```
```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg/tsan                        79    79     0     0   
==============================
TEST SUCCESS
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Man Cao](https://openjdk.org/census#manc) (@caoman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/tsan.git pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.org/tsan.git pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/tsan/pull/23.diff">https://git.openjdk.org/tsan/pull/23.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/tsan/pull/23#issuecomment-2290110948)