### PR TITLE
In TsanSymbolize, use ThreadInVMfromUnknown to transition to VM state.

### DIFF
--- a/src/hotspot/share/tsan/tsan.cpp
+++ b/src/hotspot/share/tsan/tsan.cpp
@@ -98,7 +98,7 @@ JNIEXPORT void TsanSymbolize(julong loc,
   // Method::checked_resolve_jmethod_id. That avoids assertion on thread state
   // with AccessInternal::check_access_thread_state on JDK debug binary. As
   // TsanSymbolize could be triggered from native or Java code, we can't simply
-  // make it a JVM_ENTRY to handle native -> vm state transition. See b/424368475.
+  // make it a JVM_ENTRY to handle native -> vm state transition.
   ThreadInVMfromUnknown __tiv;
 
   jmethodID method_id = SharedRuntime::tsan_method_id_from_code_location(loc);


### PR DESCRIPTION
Our internal testing on JDK 21 fastdebug binary runs into following assertion failure when tsan tries to report a race during executing a JNI native method.

```
#  Internal Error (/tmp/jdkbuild/srcs/src/hotspot/share/oops/accessBackend.cpp:224), pid=2318779, tid=2318806
#  assert(state == _thread_in_vm || state == _thread_in_Java || state == _thread_new) failed: Wrong thread state for accesses: 4
```

```
V  [libjvm.so+0x84113d]  AccessInternal::check_access_thread_state()+0x8d  (accessBackend.cpp:224)
V  [libjvm.so+0xdc65d7]  ClassLoaderData::is_alive() const+0x37
V  [libjvm.so+0x173165a]  Method::checked_resolve_jmethod_id(_jmethodID*)+0xaa
V  [libjvm.so+0x1bb3293]  TsanSymbolize+0x73
<snip>
C  [<snip>]  __tsan::ReportRace(__tsan::ThreadState*, __tsan::RawShadow*, __tsan::Shadow, __tsan::Shadow, unsigned long)+0xb2f
C  [<snip>]  WriteHeapVar+0x1d
C  [<snip>]  <JNI_native_method>
<snip>
```

The assert is hit as the thread state is `_thread_in_native`, which is not expected by `AccessInternal::check_access_thread_state`.

Since `__tsan::ReportRace ... -> TsanSymbolize` could be triggered during executing both Java code or native code, making `TsanSymbolize` a `JVM_ENTRY` for transitioning into VM state does not work in all cases. Instead, `ThreadInVMfromUnknown` is used for transitioning into VM state only if the current JavaThread is in native. As part of the fix, I also remove `DEBUG_ONLY(NoSafepointVerifier nsv;)` from  `TsanSymbolize`. `NoSafepointVerifier nsv;)` does `JavaThread::cast(_thread)->inc_no_safepoint_count()`, which causes `_no_safepoint_count` to be `>0` and asserts during the thread state transition.

```
#  Internal Error (/tmp/jdkbuild/srcs/src/hotspot/share/runtime/javaThread.cpp:362), pid=454073, tid=454110
#  assert(false) failed: Possible safepoint reached by thread that does not allow it
```

Tested the change with tsan jtreg tests on fastdebug build. The fix was also tested with the affected internal tests on fastdebug build.

```
$ bash configure --with-boot-jdk=/usr/local/google/home/jianglizhou/openjdk/jdk-21.0.7 --with-debug-level=fastdebug --disable-warnings-as-errors --with-jtreg=/usr/local/google/home/jianglizhou/github/jtreg/build/images/jtreg --with-stdc++lib=static --disable-precompiled-headers --enable-unlimited-crypto --with-native-debug-symbols=internal --with-default-make-target=jdk-image --disable-warnings-as-errors --with-toolchain-type=clang --disable-warnings-as-errors
```

```
$ make test TEST=hotspot/jtreg/tsan
```

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/hotspot/jtreg/tsan                        79    79     0     0   
==============================
TEST SUCCESS
```

Fix was internally reviewed by @rasbold.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Chuck Rasbold](https://openjdk.org/census#rasbold) (@rasbold - **Reviewer**) ⚠️ Review applies to [fc8cd3b9](https://git.openjdk.org/tsan/pull/24/files/fc8cd3b99338539b33ab794b3d67c6a812c25fe5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/tsan.git pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.org/tsan.git pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/tsan/pull/24.diff">https://git.openjdk.org/tsan/pull/24.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/tsan/pull/24#issuecomment-2993101819)
</details>
